### PR TITLE
actually changed

### DIFF
--- a/IterationStatements/IterationStatements.csproj
+++ b/IterationStatements/IterationStatements.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This pull request updates the target framework of the `IterationStatements` project to a newer version.

* [`IterationStatements/IterationStatements.csproj`](diffhunk://#diff-eff33b377ae9f4e24e03b1a343f67c5ff7cbcd5708f061f2f8312df2050cbe08L5-R5): Changed the target framework from `net6.0` to `net9.0`, ensuring compatibility with the latest features and improvements in .NET.